### PR TITLE
Fix example code to reflect exported name

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ import { basicSetup } from 'codemirror';
 import { EditorState } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
 import { css } from '@codemirror/lang-css';
-import { cssColorPicker } from '@replit/codemirror-css-color-picker';
+import { colorPicker } from '@replit/codemirror-css-color-picker';
 
 new EditorView({
   parent: document.querySelector('#editor'),
@@ -23,7 +23,7 @@ new EditorView({
     extensions: [
       basicSetup,
       css(),
-      cssColorPicker({
+      colorPicker({
         style: {
           wrapper: {
             outlineColor: 'transparent',


### PR DESCRIPTION
The sample code did not work, so I investigated and found that the exported name had changed.