### PR TITLE
Support rgba expressions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ enum ColorType {
 }
 
 const rgbCallExpRegex =
-  /rgb\(\s*(\d{1,3}%?)\s*,?\s*(\d{1,3}%?)\s*,?\s*(\d{1,3}%?)\s*(,\s*0?\.\d+)?\)/;
+  /rgb(?:a)?\(\s*(\d{1,3}%?)\s*,?\s*(\d{1,3}%?)\s*,?\s*(\d{1,3}%?)\s*(,\s*0?\.\d+)?\)/;
 const hslCallExpRegex =
   /hsl\(\s*(\d{1,3})\s*,\s*(\d{1,3})%\s*,\s*(\d{1,3})%\s*(,\s*0?\.\d+)?\)/;
 
@@ -116,6 +116,11 @@ function colorPickersDecorations(view: EditorView) {
           const colorName = view.state.doc.sliceString(from, to);
           if (namedColors.has(colorName)) {
             const color = namedColors.get(colorName);
+
+            if (!color) {
+              return;
+            }
+
             const widget = Decoration.widget({
               widget: new ColorPickerWidget({
                 colorType: ColorType.named,

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,11 +116,6 @@ function colorPickersDecorations(view: EditorView) {
           const colorName = view.state.doc.sliceString(from, to);
           if (namedColors.has(colorName)) {
             const color = namedColors.get(colorName);
-
-            if (!color) {
-              return;
-            }
-
             const widget = Decoration.widget({
               widget: new ColorPickerWidget({
                 colorType: ColorType.named,


### PR DESCRIPTION
fixes WS-718

# Why

We can support `rgba`, and while the built-in browser input color picker doesn't support alpha values, we can at least modify the `rgb` value

# What changed

Add a non-capturing group for `a` part of `rgba`. This doesn't change anything as all the capturing groups are the same and we already accounted for the short hand of `rgba` i.e. `rgb(r, g, b, a)`

# Test plan

- rgb works, color can be changed
- rgb with alpha value, color can be changed, alpha value remains constant
- rgba color can be changed, alpha value remains constant

<!-- 
 - Test plans should allow people without context to run through a list of steps and assert behavior.
 - If this is a bug fix, the test plan should include steps to reproduce the problem.
 - If this is a feature, the test plan should reflect a human-readable end-to-end test.
-->
