### PR TITLE
Fix example to work with the current version

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,21 +34,6 @@ new EditorView({
 });
 ```
 
-```ts
-interface CSSColorPickerOptions {
-  /**
-   * Additional [`style-mod`](https://github.com/marijnh/style-mod#documentation)
-   * style spec providing theme for the color picker.
-   */
-  style?: {
-    /** Style spec for the color picker `<div>` container */
-    wrapper?: StyleSpec;
-    /** Style spec for the color picker `<input>` element */
-    input?: StyleSpec;
-  };
-}
-```
-
 ### Todos
 
 - Investigate solutions for alpha values. `input[type="color"]` doesn't support alpha values, we could show another number input next to it for the alpha value.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ import { basicSetup } from 'codemirror';
 import { EditorState } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
 import { css } from '@codemirror/lang-css';
-import { colorPicker } from '@replit/codemirror-css-color-picker';
+import { colorPicker, wrapperClassName } from '@replit/codemirror-css-color-picker';
 
 new EditorView({
   parent: document.querySelector('#editor'),
@@ -23,11 +23,10 @@ new EditorView({
     extensions: [
       basicSetup,
       css(),
-      colorPicker({
-        style: {
-          wrapper: {
-            outlineColor: 'transparent',
-          },
+      colorPicker,
+      EditorView.theme({
+        [`.${wrapperClassName}`]: {
+          outlineColor: 'transparent',
         },
       }),
     ],


### PR DESCRIPTION
# Why

Otherwise users would see `No constituent of type 'Extension' is callable.`

Note this was also likely the reason behind https://github.com/replit/Codemirror-CSS-color-picker/issues/10

# What changed

Example in README now follows the code in dev:

https://github.com/replit/Codemirror-CSS-color-picker/blob/3b52d6733437058383e47fce7bcac2e4ed6eb91c/dev/index.ts#L100-L107

# Test plan

Try to run the example.