### PR TITLE
Add support for new `rgb()` syntax

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export enum ColorType {
 }
 
 const rgbCallExpRegex =
-  /rgb(?:a)?\(\s*(\d{1,3}%?)\s*,?\s*(\d{1,3}%?)\s*,?\s*(\d{1,3}%?)\s*(,\s*0?\.\d+)?\)/;
+  /rgb(?:a)?\(\s*(\d{1,3}%?)\s*,?\s*(\d{1,3}%?)\s*,?\s*(\d{1,3}%?)\s*([,/]\s*0?\.?\d+%?)?\)/;
 const hslCallExpRegex =
   /hsl\(\s*(\d{1,3})\s*,\s*(\d{1,3})%\s*,\s*(\d{1,3})%\s*(,\s*0?\.\d+)?\)/;
 const hexRegex = /(^|\b)(#[0-9a-f]{3,9})(\b|$)/i;
@@ -481,7 +481,7 @@ class ColorPickerWidget extends WidgetType {
   }
 }
 
-const colorPickerTheme = EditorView.baseTheme({
+export const colorPickerTheme = EditorView.baseTheme({
   [`.${wrapperClassName}`]: {
     display: 'inline-block',
     outline: '1px solid #eee',


### PR DESCRIPTION
# Why

- The new `rgb()` syntax, e.g., `rgb(255 255 255 / 50%)` is not yet supported.
- `colorPickerTheme` is not exported, which complicates its usage for a customized color-picker extension in another language.

Closes #25

# What changed

- Update `rgbCallExpRegex` for the new `rgb()` syntax.
- Export `colorPickerTheme`.

# Test plan

Sorry, I am not familiar with Replit. However, if there is an active CodeMirror-based CSS editor with the color-picker extension enabled, the following code block will clearly show the bug:

```css
p {
	background: rgb(200 200 200 / 50%); /* no color picker shown */
	background: rgb(200, 200, 200, .5); /* color picker shown */
}
```
