### PR TITLE
fix alpha values starting with `/`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,9 +34,9 @@ export enum ColorType {
 }
 
 const rgbCallExpRegex =
-  /rgba?\(\s*(\d{1,3}%?)\s*[,\s]\s*(\d{1,3}%?)\s*[,\s]\s*(\d{1,3}%?)\s*([,/]\s*0?\.?\d+%?)?\s*\)/;
+  /rgb(?:a)?\(\s*(\d{1,3}%?)\s*,?\s*(\d{1,3}%?)\s*,?\s*(\d{1,3}%?)\s*([,/]\s*0?\.?\d+%?)?\s*\)/;
 const hslCallExpRegex =
-  /hsla?\(\s*(\d{1,3})(?:deg)?\s*[,\s]\s*(\d{1,3})%?\s*[,\s]\s*(\d{1,3})%?\s*([,/]\s*0?\.?\d+%?)?\s*\)/;
+  /hsl(?:a)?\(\s*(\d{1,3})(?:deg)?\s*,?\s*(\d{1,3})%?\s*,?\s*(\d{1,3})%?\s*([,/]\s*0?\.?\d+%?)?\s*\)/;
 const hexRegex = /(^|\b)(#[0-9a-f]{3,9})(\b|$)/i;
 
 function discoverColorsInCSS(

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,7 +153,7 @@ export function parseCallExpression(callExp: string): ColorData | null {
       return {
         colorType: ColorType.rgb,
         color,
-        alpha: a.replace(/^\//, ',') || '',
+        alpha: a?.replace(/^\//, ',') || '',
       };
     }
     case 'hsl': {
@@ -169,7 +169,7 @@ export function parseCallExpression(callExp: string): ColorData | null {
       return {
         colorType: ColorType.hsl,
         color,
-        alpha: a.replace(/^\//, ',') || '',
+        alpha: a?.replace(/^\//, ',') || '',
       };
     }
     default:

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,9 +34,9 @@ export enum ColorType {
 }
 
 const rgbCallExpRegex =
-  /rgb(?:a)?\(\s*(\d{1,3}%?)\s*,?\s*(\d{1,3}%?)\s*,?\s*(\d{1,3}%?)\s*([,/]\s*0?\.?\d+%?)?\)/;
+  /rgba?\(\s*(\d{1,3}%?)\s*[,\s]\s*(\d{1,3}%?)\s*[,\s]\s*(\d{1,3}%?)\s*([,/]\s*0?\.?\d+%?)?\s*\)/;
 const hslCallExpRegex =
-  /hsl\(\s*(\d{1,3})\s*,\s*(\d{1,3})%\s*,\s*(\d{1,3})%\s*(,\s*0?\.\d+)?\)/;
+  /hsla?\(\s*(\d{1,3})(?:deg)?\s*[,\s]\s*(\d{1,3})%?\s*[,\s]\s*(\d{1,3})%?\s*([,/]\s*0?\.?\d+%?)?\s*\)/;
 const hexRegex = /(^|\b)(#[0-9a-f]{3,9})(\b|$)/i;
 
 function discoverColorsInCSS(
@@ -153,7 +153,7 @@ export function parseCallExpression(callExp: string): ColorData | null {
       return {
         colorType: ColorType.rgb,
         color,
-        alpha: a || '',
+        alpha: a.replace(/^\//, ',') || '',
       };
     }
     case 'hsl': {
@@ -169,7 +169,7 @@ export function parseCallExpression(callExp: string): ColorData | null {
       return {
         colorType: ColorType.hsl,
         color,
-        alpha: a || '',
+        alpha: a.replace(/^\//, ',') || '',
       };
     }
     default:


### PR DESCRIPTION
# Why

I apologize that my last PR (#26) did not test the interaction with the color input element. Because the change handler of the color input always convert RGB colors using the comma-delimited legacy syntax (L546-L548), the parsed alpha value should always start with `,` instead of `/`.

https://github.com/replit/Codemirror-CSS-color-picker/blob/ef2bb1e0ab4831aca47ad8b20d32a139ebe0e173/src/index.ts#L546-L548

# What changed

- The parsed alpha value from `rgb()` will always start with `,` even for the new syntax using `/`.
- The HSL color regex is updated according to [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl).

# Test plan

Given the CSS code block below in a CodeMirror editor:

```css
p {
  color: rgb(255 255 255 / 90%);
  color: rgb( 255 255 255 / 90% );
  color: hsla( 120deg 75 25 / 90% );
}
```

A color input element is now rendered on L2 but not on L3 and L4 by the color-picker extension. Click on the color input element and change the color to red (`#f00`), and the color string will be updated to `rgb(255, 0, 0/ 90%)` which is invalid.

This PR will correct the behaviors. There will be color input elements rendered on L3 and L4, and the updated color string after choosing red from the color input on L2 will be `rgb(255, 0, 0, 90%)`.